### PR TITLE
mDNS capability 

### DIFF
--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -13,7 +13,7 @@ from ubinascii import hexlify
 import uasyncio as asyncio
 gc.collect()
 from utime import ticks_ms, ticks_diff, sleep_ms
-from uerrno import EINPROGRESS, ETIMEDOUT
+from uerrno import EINPROGRESS, ETIMEDOUT, EAGAIN
 gc.collect()
 from micropython import const
 from machine import unique_id

--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -550,7 +550,7 @@ class MQTTClient(MQTT_base):
                 if e.args[0] not in BUSY_ERRORS and e.args[0] != EAGAIN:
                     raise
             await asyncio.sleep_ms(_SOCKET_POLL_DELAY)
-        raise OSError(-1)
+        raise OSError("mdns fail")
 
     async def getmdnsaddr(self, name):
         print("getmdnsaddr", name)

--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -551,9 +551,6 @@ class MQTTClient(MQTT_base):
                     raise
             await asyncio.sleep_ms(_SOCKET_POLL_DELAY)
         raise OSError(-1)
-        
-        print(buf, addr)
-        return ''
 
     async def getmdnsaddr(self, name):
         print("getmdnsaddr", name)


### PR DESCRIPTION
This would fix https://github.com/peterhinch/micropython-mqtt/issues/11

Note that the `getmdnsaddr()` function only gets called when the `(server[-6:] == '.local')`

This code calls the asynchronous function `_as_mdns_send_read_udp()` to handle the UDP send and receive, which is based on `wan_ok()`.  

Unfortunately I was unable to use `sock.connect(); _as_write()` because the sending only worked with  `sock.sendto()`, and the connect() function didn't work.  This might be a UDP thing, so I don't know how it operated in the `wan_ok()` function.  

Also, I was unable to use `_as_read()` function because I don't know the length of the returning packet.  (In any case, Datagrams are not streams, so you only get the packet.)  Instead I had to use `sock.recvfrom()` which can be set to non-blocking, and it uses the same trick of `await asyncio.sleep_ms(_SOCKET_POLL_DELAY)` in a busy loop.

Additionally, I needed 4 mDNS packet parsing functions: `mdns_createrequestpacket(), mdns_extractpackedname(), mdns_lenpackedname(), mdns_decoderesponsepacket()`


My scrap-work area is here:
    https://github.com/goatchurchprime/jupyter_micropython_developer_notebooks/blob/master/basicsockets/mdnstest.ipynb 


I don't expect this to be fully up to standard with the real **micropython-mqtt** code, so treat this as a reference implementation.  (It works for me for now, though.)

The ESP8266 Arduino implementation of mDNS is utterly vast.  
    https://github.com/esp8266/Arduino/tree/master/libraries/ESP8266mDNS
I can't quite find where in it is the equivalent of the code I have here.  I based my code on an editing down of https://github.com/nickovs/slimDNS
