### PR TITLE
ESP8266 use wifi credentials if not stored on device

### DIFF
--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -457,6 +457,10 @@ class MQTTClient(MQTT_base):
             s.connect()  # ESP8266 remembers connection.
             while s.status() == network.STAT_CONNECTING:  # Break out on fail or success. Check once per sec.
                 await asyncio.sleep(1)
+            if not s.isconnected() and self._ssid is not None and self._wifi_pw is not None:
+                s.connect(self._ssid, self._wifi_pw)
+                while s.status() == network.STAT_CONNECTING:  # Break out on fail or success. Check once per sec.
+                    await asyncio.sleep(1)
         else:
 #            if not [x for x in s.scan() if x[0].decode() == self._ssid]:
 #                raise OSError


### PR DESCRIPTION
As I was reorganizing my wifi code in my project pysmartnode I realized, that the library doesn't handle the case that the esp8266 has no wifi credentials stored. The connect() coro would just exit and expect the user to handle that case.
However as a user I would expect the library to handle this case too if I provide my wifi credentials in the configuration, especially since it is handled for every other device too since those don't even connect without credentials.

So I ended up having to implement that case in my higher layer mqtt handler which is not intuitive.

This little change could solve the problem. Didn't implement it in my fork either to keep the inner workings equal.
You probably thought of this problem and had reasons not to implement it?