### PR TITLE
Added config option to set dhcp_hostname

### DIFF
--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -44,6 +44,7 @@ async def eliza(*_):  # e.g. via set_wifi_handler(coro): see test program
 
 config = {
     'client_id' : hexlify(unique_id()),
+    'hostname' : None,
     'server' : None,
     'port' : 0,
     'user' : '',
@@ -132,6 +133,8 @@ class MQTT_base:
         self._sock = None
         self._sta_if = network.WLAN(network.STA_IF)
         self._sta_if.active(True)
+        if self.hostname:
+            self._sta_if.config(dhcp_hostname=self.hostname)
 
         self.pid = 0
         self.rcv_pid = 0


### PR DESCRIPTION
As a standard the WLAN object in network registers ESP32 micro-controller with the hostname 'espressif' when getting an ip adress from the dhcp server.

This commit adds the attribute 'hostname' to the config dict. When 'hostname' is configured, it is handed as 'dchp_hostname' to the sta_if configuration. This way, each ESP32 microcontroller can set it's individual dns entry.