### PR TITLE
esp8266 wifi stuck in STAT_CONNECTING

### DIFF
--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -509,7 +509,7 @@ class MQTTClient(MQTT_base):
                 return
             s.active(True)
             s.connect()  # ESP8266 remembers connection.
-            for _ in range(10):
+            for _ in range(60):
                 if s.status() != network.STAT_CONNECTING:  # Break out on fail or success. Check once per sec.
                     break
                 await asyncio.sleep(1)


### PR DESCRIPTION
I am able to recreate a state where the network is stuck in STAT_CONNECTING on esp8266 although it is connected, has an IP and all sockets work including webrepl. 
This might be due to waiting for a dhcp lease renewal or something else.
In any case it makes the library wait forever.

Not sure if this case could be possible on other ports as well. Esp32 might behave similarly but would it make sense to implement something similar for other ports without confirmation of it actually being a problem?

Does it even make sense to implement it for esp8266 as it is apparently a very rare situation?

This is due to the issue I raised on micropython [5261](https://github.com/micropython/micropython/issues/5261)