### PR TITLE
Separate network hardware interface from mqtt client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ An effective PC client and server is [mosquitto](https://mosquitto.org/).
 
 # This repository
 
-This contains two separate projects:  
+This contains three separate projects:  
  1. A "resilient" asynchronous non-blocking MQTT driver.
  2. A means of using a cheap ESP8266 module to bring MQTT to MicroPython
  platforms which lack a WiFi interface.
+ 3. A basic network hardware controller (WLAN) which the mqtt client uses
 
 ## 1. The "resilient" driver
 

--- a/mqtt_as/interfaces/__init__.py
+++ b/mqtt_as/interfaces/__init__.py
@@ -1,0 +1,79 @@
+from uerrno import EINPROGRESS, ETIMEDOUT
+import usocket
+import uasyncio as asyncio
+
+
+async def _g():
+    pass
+
+
+type_coro = type(_g())
+
+
+# If a callback is passed, run it and return.
+# If a coro is passed initiate it and return.
+# coros are passed by name i.e. not using function call syntax.
+def launch(func, tup_args):
+    res = func(*tup_args)
+    if isinstance(res, type_coro):
+        res = asyncio.create_task(res)
+    return res
+
+
+class BaseInterface:
+    def __init__(self, socket=None):
+        # Legitimate errors while waiting on a socket. See uasyncio __init__.py open_connection().
+        self.BUSY_ERRORS = [EINPROGRESS, ETIMEDOUT]
+        self.socket = socket or usocket  # support for custom socket implementations
+        self._subs = []
+        self._state = None
+
+    async def connect(self):
+        """Serve connect request"""
+        return await self._connect()
+
+    async def _connect(self):
+        """Hardware specific connect method"""
+        # return True  # if connection is successful, otherwise False
+        raise NotImplementedError()
+
+    async def disconnect(self):
+        """Serve disconnect request"""
+        return await self._disconnect()
+
+    async def _disconnect(self):
+        """Hardware specific disconnect method"""
+        # return True  # if connection is successful, otherwise False
+        raise NotImplementedError()
+
+    async def reconnect(self):
+        """Serve reconnect request"""
+        return await self._reconnect()
+
+    async def _reconnect(self):
+        """Hardware specific disconnect method"""
+        if await self._disconnect():
+            return await self._connect()
+        return False
+
+    def isconnected(self):
+        if self._isconnected():
+            if not self._state:
+                # triggers if state is False or None
+                self._state = True
+                self._launch_subs(True)
+        else:
+            if self._state:
+                # triggers if state is True
+                self._state = False
+                self._launch_subs(False)
+
+    def _isconnected(self):
+        raise NotImplementedError()
+
+    def _launch_subs(self, state):
+        for cb in self._subs:
+            launch(cb, (state,))
+
+    def subscribe(self, cb):
+        self._subs.append(cb)

--- a/mqtt_as/interfaces/wlan/__init__.py
+++ b/mqtt_as/interfaces/wlan/__init__.py
@@ -1,0 +1,72 @@
+from .. import BaseInterface
+from sys import platform
+import network
+import uasyncio as asyncio
+
+ESP8266 = platform == 'esp8266'
+ESP32 = platform == 'esp32'
+PYBOARD = platform == 'pyboard'
+
+
+class WLAN(BaseInterface):
+    def __init__(self, ssid=None, wifi_pw=None):
+        super().__init__()
+        self.DEBUG = False
+        if platform == 'esp32' or platform == 'esp32_LoBo':
+            # https://forum.micropython.org/viewtopic.php?f=16&t=3608&p=20942#p20942
+            self.BUSY_ERRORS += [118, 119]  # Add in weird ESP32 errors
+        self._ssid = ssid
+        self._wifi_pw = wifi_pw
+        # wifi credentials required for ESP32 / Pyboard D. Optional ESP8266
+        self._sta_if = network.WLAN(network.STA_IF)
+        self._sta_if.active(True)
+        if platform == "esp8266":
+            import esp
+            esp.sleep_type(0)  # Improve connection integrity at cost of power consumption.
+
+    async def _connect(self):
+        s = self._sta_if
+        if ESP8266:
+            if s.isconnected():  # 1st attempt, already connected.
+                return True
+            s.active(True)
+            s.connect()  # ESP8266 remembers connection.
+            for _ in range(60):
+                if s.status() != network.STAT_CONNECTING:  # Break out on fail or success. Check once per sec.
+                    break
+                await asyncio.sleep(1)
+            if s.status() == network.STAT_CONNECTING:  # might hang forever awaiting dhcp lease renewal or something else
+                s.disconnect()
+                await asyncio.sleep(1)
+            if not s.isconnected() and self._ssid is not None and self._wifi_pw is not None:
+                s.connect(self._ssid, self._wifi_pw)
+                while s.status() == network.STAT_CONNECTING:  # Break out on fail or success. Check once per sec.
+                    await asyncio.sleep(1)
+        else:
+            s.active(True)
+            s.connect(self._ssid, self._wifi_pw)
+            if PYBOARD:  # Doesn't yet have STAT_CONNECTING constant
+                while s.status() in (1, 2):
+                    await asyncio.sleep(1)
+            else:
+                while s.status() == network.STAT_CONNECTING:  # Break out on fail or success. Check once per sec.
+                    await asyncio.sleep(1)
+
+        if not s.isconnected():
+            return False
+        # Ensure connection stays up for a few secs.
+        if self.DEBUG:
+            print('Checking WiFi integrity.')
+        for _ in range(5):
+            if not s.isconnected():
+                return False  # in 1st 5 secs
+            await asyncio.sleep(1)
+        if self.DEBUG:
+            print('Got reliable connection')
+        return True
+
+    async def _disconnect(self):
+        self._sta_if.disconnect()
+
+    def _isconnected(self):
+        return self._sta_if.isconnected()


### PR DESCRIPTION
Goal:
- Easier maintainability of the repository (network interfaces and hardware keep growing)
- mqtt client easier usable with a variety of network interfaces (none for unix, wlan, ethernet, custom interfaces)
- users/devs can write their own network interface integration

This is a first draft that hasn't been tested yet. Looking for feedback on the implementation.