### PR TITLE
Remove doc stating that TLS does not work on ESP32. 

### DIFF
--- a/mqtt_as/README.md
+++ b/mqtt_as/README.md
@@ -110,8 +110,7 @@ providing and testing a number of bugfixes and enhancements.
 
 SSL/TLS on ESP8266 is
 [not supported](https://github.com/micropython/micropython/issues/7473#issuecomment-871074210),
-and it looks as if this isn't going to be fixed in the near future. ESP32
-support was promised for firmware V1.14 but hasn't materialised as of V1.16.
+and it looks as if this isn't going to be fixed in the near future.
 
 8th April 2020-10th March 2021
 Adapted for new `uasyncio`.
@@ -179,12 +178,9 @@ messages without failure or data loss.
  1. `lowpower.py` Pyboard D micro-power test. See [Section 5](./README.md#5-low-power-demo).
  2. `tls8266.py` SSL/TLS connectionfor ESP8266. Fails with 
  `ssl_handshake_status: -4`.
- 3. `tls32.py` SSL/TLS connection for ESP32. Fails with
- `mbedtls_ssl_handshake error: -77`.
 
 Re TLS: It seems that the problem is due to lack of firmware support for TLS
-on nonblocking sockets. This was scheduled to be fixed for V1.14 but seems not
-to have happened.
+on nonblocking sockets.
 
 ### config.py
 

--- a/mqtt_as/tls32.py
+++ b/mqtt_as/tls32.py
@@ -1,7 +1,3 @@
-# tls32.py Test of asynchronous mqtt client with SSL for ESP32. Fails with
-# mbedtls_ssl_handshake error: -77
-# Please help me fix it.
-
 # (C) Copyright Peter Hinch 2017-2019.
 # Released under the MIT licence.
 


### PR DESCRIPTION
Using Micropython 1.16-135, I have found out that ESP32 can in fact run an encrypted connection and communicate with it on non-blocking sockets.

Certificate and key were made using RSA2048b with AWS IoT service.
They were pushed in the config like so:
`config['ssl_params'] = {'cert: 'content_of_cert', 'key': 'content_of_key'}`
```
MicroPython v1.16-135-gaecb697c7-dirty on 2021-07-28; ESP32 module with ESP32
Type "help()" for more information.
>>> import tls32
Checking WiFi integrity.
Got reliable connection
Connecting to broker.
Connected to broker.
Wifi is  up
publish 0
Topic = result Count = 0 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 1
Topic = result Count = 1 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 2
Topic = result Count = 2 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 3
Topic = result Count = 3 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 4
Topic = result Count = 4 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 5
Topic = result Count = 5 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 6
Topic = result Count = 6 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 7
Topic = result Count = 7 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 8
Topic = result Count = 8 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
publish 9
Topic = result Count = 9 Retransmissions = 0 Retained = False
RAM free 82016 alloc 29152
```
