### PR TITLE
Update mqtt_as.py - move DNS ip to config

### DIFF
--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -99,6 +99,7 @@ config = {
     "connect_coro": eliza,
     "ssid": None,
     "wifi_pw": None,
+    "wan_check_ip": "8.8.8.8",
     "queue_len": 0,
 }
 
@@ -321,7 +322,7 @@ class MQTT_base:
         length = 32  # DNS query and response packet size
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         s.setblocking(False)
-        s.connect(("8.8.8.8", 53))
+        s.connect((config["wan_check_ip"], 53))
         await asyncio.sleep(1)
         try:
             await self._as_write(packet, sock=s)


### PR DESCRIPTION
A very simple change to change the "wan_ok" DNS check IP address to become a config item. I had the need to change the default 8.8.8.8 to a local DNS server address for a LAN with no internet connection.