### PR TITLE
Change ussl to ssl

### DIFF
--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -276,9 +276,9 @@ class MQTT_base:
         await asyncio.sleep_ms(_DEFAULT_MS)
         self.dprint("Connecting to broker.")
         if self._ssl:
-            import ussl
+            import ssl
 
-            self._sock = ussl.wrap_socket(self._sock, **self._ssl_params)
+            self._sock = ssl.wrap_socket(self._sock, **self._ssl_params)
         premsg = bytearray(b"\x10\0\0\0\0\0")
         msg = bytearray(b"\x04MQTT\x04\0\0\0")  # Protocol 3.1.1
 

--- a/mqtt_as/mqtt_as.py
+++ b/mqtt_as/mqtt_as.py
@@ -276,7 +276,10 @@ class MQTT_base:
         await asyncio.sleep_ms(_DEFAULT_MS)
         self.dprint("Connecting to broker.")
         if self._ssl:
-            import ssl
+            try:
+                import ssl
+            except ImportError:
+                import ussl as ssl
 
             self._sock = ssl.wrap_socket(self._sock, **self._ssl_params)
         premsg = bytearray(b"\x10\0\0\0\0\0")


### PR DESCRIPTION
At least on Pico W, MicroPython 1.23.0 no longer has `ussl`. Instead it only has `ssl` (which was also available before 1.23.0).

Not sure if something will be changed later. https://github.com/micropython/micropython/releases/tag/v1.23.0