### PR TITLE
sleep(1) to avoid persistent reconnect failures on esp32

### DIFF
--- a/mqtt_as/__init__.py
+++ b/mqtt_as/__init__.py
@@ -751,8 +751,12 @@ class MQTTClient(MQTT_base):
                 if ESP32:
                     # Status values >= STAT_IDLE can occur during connect:
                     # STAT_IDLE 1000, STAT_CONNECTING 1001, STAT_GOT_IP 1010
-                    if s.status() < network.STAT_IDLE:  # Error statuses
-                        break  # are in range 200..204
+                    # Error statuses are in range 200..204
+                    if s.status() < network.STAT_IDLE:
+                        # pause as workaround to avoid persistent reconnect failures
+                        # see https://github.com/peterhinch/micropython-mqtt/issues/132 for details
+                        await asyncio.sleep(1)
+                        break
                 elif PYBOARD:  # No symbolic constants in network
                     if not 1 <= s.status() <= 2:
                         break


### PR DESCRIPTION
Hello Peter, I have the same problem as described in #132.  My esp doesn't reconnect after my wifi router is temporary down. (I use [this one](https://de.aliexpress.com/item/1005001838731651.html) ("Color": ESP-32 38PIN)) 
I debugged it: After each s.connect(...) the call to s.status() constantly reports 202 (STAT_WRONG_PASSWORD)
However, when I interrupt and try to connect from the REPL, I can connect. So I added this sleep(1) to wait a little bit before the next connect. With this little nap, the esp succeeds to connect.