### PR TITLE
Fix utf8 characters in messages and topics

### DIFF
--- a/mqtt_as/__init__.py
+++ b/mqtt_as/__init__.py
@@ -834,8 +834,8 @@ class MQTTClient(MQTT_base):
                 # A delay > 0 is necessary for webrepl compatibility.
                 await asyncio.sleep_ms(5)  # Let other tasks get lock
 
-        except OSError:
-            pass
+        except OSError as e:
+            self.dprint("_handle_msg OSError: %s", e)
         self._reconnect()  # Broker or WiFi fail.
 
     # Keep broker alive MQTT spec 3.1.2.10 Keep Alive.
@@ -873,11 +873,13 @@ class MQTTClient(MQTT_base):
             return True
 
         if self._isconnected and not self._sta_if.isconnected():  # It's going down.
+            self.dprint("isconnected(): WiFi link itself is down")
             self._reconnect()
         return self._isconnected
 
     def _reconnect(self):  # Schedule a reconnection if not underway.
         if self._isconnected:
+            self.dprint("_reconnect() triggered")
             self._isconnected = False
             asyncio.create_task(self._kill_tasks(True))  # Shut down tasks and socket
             if self._events:  # Signal an outage
@@ -928,8 +930,8 @@ class MQTTClient(MQTT_base):
             await self._connection()
             try:
                 return await super().subscribe(topic, qos, properties)
-            except OSError:
-                pass
+            except OSError as e:
+                self.dprint("subscribe(%s) OSError: %s", topic, e)
             self._reconnect()  # Broker or WiFi fail.
 
     async def unsubscribe(self, topic, properties=None):
@@ -937,8 +939,8 @@ class MQTTClient(MQTT_base):
             await self._connection()
             try:
                 return await super().unsubscribe(topic, properties)
-            except OSError:
-                pass
+            except OSError as e:
+                self.dprint("unsubscribe(%s) OSError: %s", topic, e)
             self._reconnect()  # Broker or WiFi fail.
 
     async def publish(self, topic, msg, retain=False, qos=0, properties=None):
@@ -947,6 +949,6 @@ class MQTTClient(MQTT_base):
             await self._connection()
             try:
                 return await super().publish(topic, msg, retain, qos, properties)
-            except OSError:
-                pass
+            except OSError as e:
+                self.dprint("publish(%s) OSError: %s", topic, e)
             self._reconnect()  # Broker or WiFi fail.

--- a/mqtt_as/__init__.py
+++ b/mqtt_as/__init__.py
@@ -285,6 +285,9 @@ class MQTT_base:
             await asyncio.sleep_ms(0)
 
     async def _send_str(self, s):
+        # encode string to bytes to get correct length
+        if isinstance(s, str):
+            s = s.encode("utf-8")
         await self._as_write(struct.pack("!H", len(s)))
         await self._as_write(s)
 
@@ -494,6 +497,11 @@ class MQTT_base:
             self.REPUB_COUNT += 1
 
     async def _publish(self, topic, msg, retain, qos, dup, pid, properties=None):
+        # encode string to bytes to get correct length
+        if isinstance(topic, str):
+            topic = topic.encode("utf-8")
+        if isinstance(msg, str):
+            msg = msg.encode("utf-8")
         pkt = bytearray(b"\x30\0\0\0")
         pkt[0] |= qos << 1 | retain | dup << 3
         sz = 2 + len(topic) + len(msg)
@@ -522,6 +530,9 @@ class MQTT_base:
     # Subscribe/unsubscribe
     # Can raise OSError if WiFi fails. Subclass traps.
     async def _usub(self, topic, qos, properties):
+        # encode string to bytes to get correct length
+        if isinstance(topic, str):
+            topic = topic.encode("utf-8")
         sub = qos is not None
         pkt = bytearray(7)
         pkt[0] = 0x82 if sub else 0xA2

--- a/mqtt_as/tests/v3/test.py
+++ b/mqtt_as/tests/v3/test.py
@@ -149,6 +149,23 @@ async def run_tests():
     r = await request_unsub(topic, msg)
     print(f"Unsubscribe test {FAIL if r else PASS}\n")
 
+    print("Remote publication test - non-ASCII topic and message.")
+    # Multi-byte UTF-8 chars: code-point count != byte count. Regression test
+    # for len() being applied to str rather than encoded bytes.
+    topic = "tëst/tòpïc/日本語"
+    msg = "Emoji test: 😀🚀 café naïve"
+    r = await request_pub(topic, msg)
+    print(f"Publish test {PASS if r else FAIL}\n")
+
+    print("Remote subscription test - non-ASCII topic and message.")
+    r = await request_sub(topic, msg)
+    print(f"Subscribe test {PASS if r else FAIL}\n")
+
+    print("Remote unsubscribe test - non-ASCII topic and message.")
+    # Request unsubscription. Should fail to respond to challenge publication
+    r = await request_unsub(topic, msg)
+    print(f"Unsubscribe test {FAIL if r else PASS}\n")
+
     print("Remote unsubscribe test - target not subscribed to topic.")
     # Request unsubscription. Should fail to respond to challenge publication
     r = await request_unsub("rats", "nonsense")

--- a/mqtt_as/tests/v5/test.py
+++ b/mqtt_as/tests/v5/test.py
@@ -155,6 +155,23 @@ async def run_tests():
     r = await request_unsub(topic, msg)
     print(f"Unsubscribe test {FAIL if r else PASS}\n")
 
+    print("Remote publication test - non-ASCII topic and message.")
+    # Multi-byte UTF-8 chars: code-point count != byte count. Regression test
+    # for len() being applied to str rather than encoded bytes.
+    topic = "tëst/tòpïc/日本語"
+    msg = "Emoji test: 😀🚀 café naïve"
+    r = await request_pub(topic, msg)
+    print(f"Publish test {PASS if r else FAIL}\n")
+
+    print("Remote subscription test - non-ASCII topic and message.")
+    r = await request_sub(topic, msg)
+    print(f"Subscribe test {PASS if r else FAIL}\n")
+
+    print("Remote unsubscribe test - non-ASCII topic and message.")
+    # Request unsubscription. Should fail to respond to challenge publication
+    r = await request_unsub(topic, msg)
+    print(f"Unsubscribe test {FAIL if r else PASS}\n")
+
     print("Remote unsubscribe test - target not subscribed to topic.")
     # Request unsubscription. Should fail to respond to challenge publication
     r = await request_unsub("rats", "nonsense")


### PR DESCRIPTION
Hi,

I had broken connections when trying to publish messages with `°C` in them.
Traced it to the `len()` function in python counting characters, but for non-ascii characters, that count is not the same as the number of bytes, which the code expects to build the mqtt messages.

This PR encodes message and topic strings to bytes before they are counted.  
Tests are included. I've also added additional debug messages to find out what was going on.

Regards,
  EmTeedee